### PR TITLE
fix: resolve all TypeScript compilation errors in frontend

### DIFF
--- a/app/src/features/habit-management/components/BulkDeactivateDialog.tsx
+++ b/app/src/features/habit-management/components/BulkDeactivateDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styles from '../../../styles/features/habit-management/BulkDeactivateDialog.module.css';
-import { Habit } from '../types/habit.types';
+import type { Habit } from '../types/habit.types';
 
 interface BulkDeactivateDialogProps {
   isOpen: boolean;
@@ -37,7 +37,7 @@ export const BulkDeactivateDialog: React.FC<BulkDeactivateDialogProps> = ({
 
   const handleConfirm = async () => {
     const deactivationReason = reason === 'other' ? customReason : reason;
-    const habitIds = selectedHabits.map(h => h.id);
+    const habitIds = selectedHabits.map(h => h.id.toString());
     
     await onBulkDeactivate(habitIds, deactivationReason);
     resetForm();

--- a/app/src/features/habit-management/components/BulkEditModal.tsx
+++ b/app/src/features/habit-management/components/BulkEditModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styles from '../../../styles/features/habit-management/BulkEditModal.module.css';
-import { Habit, UpdateHabitDto } from '../types/habit.types';
+import type { Habit, UpdateHabitRequest } from '../types/habit.types';
 import { ColorPicker } from './ColorPicker';
 import { IconSelector } from './IconSelector';
 import { FrequencySelector } from './FrequencySelector';
@@ -11,7 +11,7 @@ interface BulkEditModalProps {
   isOpen: boolean;
   onClose: () => void;
   selectedHabits: Habit[];
-  onBulkEdit: (updates: Partial<UpdateHabitDto>) => Promise<void>;
+  onBulkEdit: (updates: Partial<UpdateHabitRequest>) => Promise<void>;
   onBulkDeactivate?: (habitIds: string[], reason?: string) => Promise<void>;
   isLoading?: boolean;
 }
@@ -20,7 +20,7 @@ interface BulkEditFormData {
   name?: string;
   color?: string;
   icon?: string;
-  frequency?: 'daily' | 'weekly' | 'monthly';
+  frequency?: 'Daily' | 'Weekly' | 'Custom';
   isActive?: boolean;
 }
 
@@ -62,7 +62,7 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
   };
 
   const handleConfirm = async () => {
-    const updates: Partial<UpdateHabitDto> = {};
+    const updates: Partial<UpdateHabitRequest> = {};
     fieldsToUpdate.forEach(field => {
       if (formData[field] !== undefined) {
         (updates as any)[field] = formData[field];
@@ -265,8 +265,8 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
                 </label>
                 {fieldsToUpdate.has('frequency') && (
                   <FrequencySelector
-                    selectedFrequency={formData.frequency || 'daily'}
-                    onFrequencySelect={(frequency) => handleInputChange('frequency', frequency)}
+                    selectedFrequency={formData.frequency || 'Daily'}
+                    onFrequencyChange={(frequency: 'Daily' | 'Weekly' | 'Custom') => handleInputChange('frequency', frequency)}
                   />
                 )}
               </div>

--- a/app/src/features/habit-management/components/EditHabitModal.tsx
+++ b/app/src/features/habit-management/components/EditHabitModal.tsx
@@ -154,12 +154,12 @@ export const EditHabitModal: React.FC<EditHabitModalProps> = ({
 
     if (formData.name !== habit.name) changes.name = formData.name;
     if (formData.description !== habit.description) {
-      changes.description = formData.description || undefined;
+      changes.description = formData.description || '';
     }
     if (formData.targetFrequency !== habit.targetFrequency) changes.targetFrequency = formData.targetFrequency;
     if (formData.targetCount !== habit.targetCount) changes.targetCount = formData.targetCount;
     if (formData.color !== habit.color) changes.color = formData.color;
-    if (formData.icon !== habit.icon) changes.icon = formData.icon || undefined;
+    if (formData.icon !== habit.icon) changes.icon = formData.icon || '';
     if (formData.displayOrder !== habit.displayOrder) changes.displayOrder = formData.displayOrder;
     if (formData.isActive !== habit.isActive) changes.isActive = formData.isActive;
 

--- a/app/src/features/habit-management/components/HabitList.tsx
+++ b/app/src/features/habit-management/components/HabitList.tsx
@@ -157,7 +157,7 @@ export const HabitList: React.FC<HabitListProps> = ({
   };
 
   const selectAllHabits = () => {
-    const allHabitIds = filteredAndSortedHabits.map(h => h.id);
+    const allHabitIds = filteredAndSortedHabits.map(h => h.id.toString());
     setSelectedHabits(new Set(allHabitIds));
   };
 
@@ -166,7 +166,7 @@ export const HabitList: React.FC<HabitListProps> = ({
   };
 
   const handleBulkEdit = async (updates: any) => {
-    const habitsToEdit = filteredAndSortedHabits.filter(h => selectedHabits.has(h.id));
+    const habitsToEdit = filteredAndSortedHabits.filter(h => selectedHabits.has(h.id.toString()));
     if (onBulkEdit) {
       await onBulkEdit(habitsToEdit, updates);
     }
@@ -174,7 +174,7 @@ export const HabitList: React.FC<HabitListProps> = ({
     setBulkSelectMode(false);
   };
 
-  const selectedHabitObjects = filteredAndSortedHabits.filter(h => selectedHabits.has(h.id));
+  const selectedHabitObjects = filteredAndSortedHabits.filter(h => selectedHabits.has(h.id.toString()));
   const hasActiveFilters = Object.keys(filter).length > 0 || searchQuery.length > 0;
 
   if (loading) {
@@ -389,8 +389,8 @@ export const HabitList: React.FC<HabitListProps> = ({
                 <div className={styles.selectionCheckbox}>
                   <input
                     type="checkbox"
-                    checked={selectedHabits.has(habit.id)}
-                    onChange={() => toggleHabitSelection(habit.id)}
+                    checked={selectedHabits.has(habit.id.toString())}
+                    onChange={() => toggleHabitSelection(habit.id.toString())}
                     className={styles.checkbox}
                   />
                 </div>

--- a/app/src/features/habit-management/hooks/useBulkEdit.ts
+++ b/app/src/features/habit-management/hooks/useBulkEdit.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { Habit, UpdateHabitDto } from '../types/habit.types';
+import type { Habit, UpdateHabitRequest } from '../types/habit.types';
 import { habitApi } from '../services/habitApi';
 
 interface BulkEditState {
@@ -9,7 +9,7 @@ interface BulkEditState {
     total: number;
     completed: number;
     failed: number;
-    current?: string;
+    current?: string | undefined;
   } | null;
 }
 
@@ -43,7 +43,7 @@ export const useBulkEdit = () => {
 
   const bulkEditHabits = useCallback(async (
     habits: Habit[],
-    updates: Partial<UpdateHabitDto>,
+    updates: Partial<UpdateHabitRequest>,
     onProgress?: (completed: number, total: number, current: string) => void
   ): Promise<BulkEditResult> => {
     setState({
@@ -62,17 +62,17 @@ export const useBulkEdit = () => {
           updateProgress(completed, habits.length, failed, habit.name);
           onProgress?.(completed, habits.length, habit.name);
 
-          await habitApi.updateHabit(habit.id, updates);
+          await habitApi.updateHabit(habit.id, updates as UpdateHabitRequest);
           
           results.push({
-            habitId: habit.id,
+            habitId: habit.id.toString(),
             success: true
           });
           completed++;
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
           results.push({
-            habitId: habit.id,
+            habitId: habit.id.toString(),
             success: false,
             error: errorMessage
           });
@@ -128,7 +128,7 @@ export const useBulkEdit = () => {
           updateProgress(completed, habitIds.length, failed, `Habit ${habitId}`);
           onProgress?.(completed, habitIds.length, `Habit ${habitId}`);
 
-          await habitApi.deactivateHabit(Number(habitId), { reason });
+          await habitApi.deactivateHabit(Number(habitId), reason);
           
           results.push({
             habitId,

--- a/app/src/features/habit-management/hooks/useEditHabit.ts
+++ b/app/src/features/habit-management/hooks/useEditHabit.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { habitApi } from '../services/habitApi';
-import type { Habit, UpdateHabitRequest, EditHabitRequest } from '../types/habit.types';
+import type { EditHabitRequest } from '../types/habit.types';
 
 interface UseEditHabitReturn {
   editHabit: (id: number, data: EditHabitRequest) => Promise<any>;

--- a/app/src/features/habit-management/hooks/useEditMode.tsx
+++ b/app/src/features/habit-management/hooks/useEditMode.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useContext, createContext, useRef, useEffect } from 'react';
-import { Habit } from '../types/habit.types';
+import { useState, useCallback, useContext, createContext, useRef, useEffect, type ReactNode } from 'react';
+import type { Habit } from '../types/habit.types';
 
 interface EditSession {
   habitId: string;
@@ -47,7 +47,7 @@ const useStandaloneEditMode = () => {
     isDirty: false
   });
 
-  const sessionTimeoutRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  const sessionTimeoutRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   // Auto-cleanup edit sessions after 30 minutes of inactivity
   const SESSION_TIMEOUT = 30 * 60 * 1000; // 30 minutes
@@ -197,7 +197,11 @@ const useStandaloneEditMode = () => {
 };
 
 // Provider component for sharing edit mode state across components
-export const EditModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+interface EditModeProviderProps {
+  children: ReactNode;
+}
+
+export const EditModeProvider = ({ children }: EditModeProviderProps) => {
   const editMode = useStandaloneEditMode();
 
   return (

--- a/app/src/features/habit-management/hooks/useHabitValidation.ts
+++ b/app/src/features/habit-management/hooks/useHabitValidation.ts
@@ -21,7 +21,7 @@ export const useHabitValidation = (): UseHabitValidationReturn => {
   const validateField = useCallback((
     field: string, 
     value: any, 
-    data: UpdateHabitRequest | EditHabitRequest
+    _data: UpdateHabitRequest | EditHabitRequest
   ): string | null => {
     switch (field) {
       case 'name':

--- a/app/src/features/habit-management/services/habitApi.ts
+++ b/app/src/features/habit-management/services/habitApi.ts
@@ -142,7 +142,7 @@ class HabitApiService {
   // Deactivate a habit while preserving history
   async deactivateHabit(id: number, reason?: string): Promise<void> {
     const data: DeactivateHabitRequest = {
-      reason,
+      reason: reason || '',
       preserveCompletions: true
     };
 

--- a/app/src/features/tracker-switching/services/trackerCache.ts
+++ b/app/src/features/tracker-switching/services/trackerCache.ts
@@ -126,7 +126,7 @@ class TrackerCache {
     this.clear();
   }
 
-  preload(trackerIds: number[]): void {
+  preload(_trackerIds: number[]): void {
     // This would trigger background loading
     // Implementation would depend on the API service
     // TODO: Implement actual preloading logic


### PR DESCRIPTION
- Fix React import and JSX issues in useEditMode by renaming to .tsx
- Fix type imports to use 'type' keyword for verbatimModuleSyntax
- Convert habit IDs to strings for consistency in bulk operations
- Fix frequency type from lowercase to PascalCase (Daily, Weekly, Custom)
- Update FrequencySelector prop from onFrequencySelect to onFrequencyChange
- Fix optional property assignments with proper defaults
- Remove unused imports and parameters
- Ensure all type definitions align with API expectations

Build now completes successfully without TypeScript errors.